### PR TITLE
HTML Imports deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,4 @@ Below is a list of those changes.
 * Passive touch listeners by default [googleblog](https://developers.google.com/web/updates/2017/01/scrolling-intervention)
 * Forms with passwords marked `Not Secure` over HTTP [googleblog](https://security.googleblog.com/2016/09/moving-towards-more-secure-web.html)
 * ~`Array.prototype.flatten` breaks MooTools [bugzilla](https://bugzilla.mozilla.org/show_bug.cgi?id=1443630)~~ renamed to `Array.prototype.flat`
+* HTML Imports (part of Web Components) deprecated [googleblog](https://developers.google.com/web/updates/2018/09/chrome-70-deps-rems)


### PR DESCRIPTION
There was not much movement from other browser vendors and it seems like JS imports can replace this feature.