### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,6 @@ Below is a list of those changes.
 * Forms with passwords marked `Not Secure` over HTTP [googleblog](https://security.googleblog.com/2016/09/moving-towards-more-secure-web.html)
 * ~~`Array.prototype.flatten` breaks MooTools [bugzilla](https://bugzilla.mozilla.org/show_bug.cgi?id=1443630)~~ [renamed](https://developers.google.com/web/updates/2018/03/smooshgate) to `Array.prototype.flat`
 * Full page layout is no longer synchronous [googleblog](https://developers.google.com/web/updates/2018/07/site-isolation#full-page_layout_is_no_longer_synchronous)
-* HTML Imports (part of Web Components) deprecated [googleblog](https://developers.google.com/web/updates/2018/09/chrome-70-deps-rems)
+* HTML Imports (part of Web Components v0) deprecated [googleblog](https://developers.google.com/web/updates/2018/09/chrome-70-deps-rems)
 * Cookies changed from `SameSite=None` to `SameSite=Lax` by default [chromestatus](https://www.chromestatus.com/feature/5088147346030592) [tweet](https://twitter.com/simonw/status/1422366158171238400)
 * `alert()` and `confirm()` removed from cross-origin iframes [chromestatus](https://www.chromestatus.com/feature/5148698084376576) [tweet](https://twitter.com/chriscoyier/status/1420027533005836298)


### PR DESCRIPTION
Web components v1, the accepted standard, did not include html imports